### PR TITLE
Option to update session data via /me end-point

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
@@ -233,7 +233,7 @@ class DbAuthMiddleware extends Middleware
                     if(!$returnedColumns){
                         $columnNames = $table->getColumnNames();
                     }else{
-                        $columnNames = array_map)('trim',explode(',',$returnedColumns));
+                        $columnNames = array_map('trim',explode(',',$returnedColumns));
                         $columnNames[] = $passwordColumnName;
                         $columnNames  = array_values(array_unique($columnNames));
                     }


### PR DESCRIPTION
Changes
`$_SESSION['user']['updatedAt']` - set to time when the session was created/updated dbAuth.refreshSession - number of minutes after which the session data is refreshed when the /me end-point is called
`dbAuth.refreshSession` - number of minutes after which the session data is refreshed, defaults to zero,i.e., session not updated ever.
